### PR TITLE
Add URLScan analyzer support and configurable retries per analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This MCP server makes these benefits accessible to MCP-compatible clients, enabl
 2.  **Cortex Instance**: A running Cortex instance is required.
     *   The server needs network access to this Cortex instance.
     *   An API key for Cortex with permissions to list analyzers and run jobs.
-3.  **Configured Analyzers**: The specific analyzers you intend to use (e.g., `AbuseIPDB_1_0`, `Abuse_Finder_3_0`, `VirusTotal_Scan_3_1`) must be enabled and correctly configured within your Cortex instance.
+3.  **Configured Analyzers**: The specific analyzers you intend to use (e.g., `AbuseIPDB_1_0`, `Abuse_Finder_3_0`, `VirusTotal_Scan_3_1`, `Urlscan_io_Scan_0_1_0`) must be enabled and correctly configured within your Cortex instance.
 
 ## Installation
 
@@ -70,6 +70,9 @@ The tools currently use the following analyzers by default (though these can oft
     *   AbuseFinder might have its own configuration requirements or dependencies within Cortex.
 *   **`scan_url_with_virustotal`**: Uses an analyzer like `VirusTotal_Scan_3_1`.
     *   This analyzer requires a VirusTotal API key. Ensure this is configured in Cortex.
+*   **`analyze_url_with_urlscan_io`**: Uses an analyzer like `Urlscan_io_Scan_0_1_0`.
+    *   This analyzer requires an API key for urlscan.io. Ensure this is configured in Cortex.
+
 
 **Key Points:**
 
@@ -133,6 +136,14 @@ The server provides the following tools, which can be called by an MCP client:
     *   **Parameters**:
         *   `url` (string, required): The URL to scan.
         *   `analyzer_name` (string, optional): The specific name of the VirusTotal_Scan analyzer instance in Cortex. Defaults to `VirusTotal_Scan_3_1`.
+
+4.  **`analyze_url_with_urlscan_io`**
+    *   **Description**: Analyzes a URL using a Urlscan.io analyzer (e.g., `Urlscan_io_Scan_0_1_0`) via Cortex. Returns the job report if successful.
+    *   **Parameters**:
+        *   `url` (string, required): The URL to analyze.
+        *   `analyzer_name` (string, optional): The specific name of the Urlscan.io analyzer instance in Cortex. Defaults to `Urlscan_io_Scan_0_1_0`.
+
+
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The server provides the following tools, which can be called by an MCP client:
     *   **Parameters**:
         *   `ip` (string, required): The IP address to analyze.
         *   `analyzer_name` (string, optional): The specific name of the AbuseIPDB analyzer instance in Cortex. Defaults to `AbuseIPDB_1_0`.
+        *   `max_retries` (integer, optional): Maximum number of times to poll for the analyzer job to complete. Defaults to 5.
 
 2.  **`analyze_with_abusefinder`**
     *   **Description**: Analyzes various types of data (IP, domain, FQDN, URL, or email) using an AbuseFinder analyzer via Cortex. Returns the job report if successful.
@@ -130,18 +131,21 @@ The server provides the following tools, which can be called by an MCP client:
         *   `data` (string, required): The data to analyze (e.g., "1.1.1.1", "example.com", "http://evil.com/malware", "test@example.com").
         *   `data_type` (string, required): The type of the data. Must be one of: `ip`, `domain`, `fqdn`, `url`, `mail`.
         *   `analyzer_name` (string, optional): The specific name of the AbuseFinder analyzer instance in Cortex. Defaults to `Abuse_Finder_3_0`.
+        *   `max_retries` (integer, optional): Maximum number of times to poll for the analyzer job to complete. Defaults to 5.
 
 3.  **`scan_url_with_virustotal`**
     *   **Description**: Scans a URL using a VirusTotal_Scan analyzer (e.g., `VirusTotal_Scan_3_1`) via Cortex. Returns the job report if successful.
     *   **Parameters**:
         *   `url` (string, required): The URL to scan.
         *   `analyzer_name` (string, optional): The specific name of the VirusTotal_Scan analyzer instance in Cortex. Defaults to `VirusTotal_Scan_3_1`.
+        *   `max_retries` (integer, optional): Maximum number of times to poll for the analyzer job to complete. Defaults to 5.
 
 4.  **`analyze_url_with_urlscan_io`**
     *   **Description**: Analyzes a URL using a Urlscan.io analyzer (e.g., `Urlscan_io_Scan_0_1_0`) via Cortex. Returns the job report if successful.
     *   **Parameters**:
         *   `url` (string, required): The URL to analyze.
         *   `analyzer_name` (string, optional): The specific name of the Urlscan.io analyzer instance in Cortex. Defaults to `Urlscan_io_Scan_0_1_0`.
+        *   `max_retries` (integer, optional): Maximum number of times to poll for the analyzer job to complete. Defaults to 5.
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,7 @@ mod common {
         job_request: cortex_client::models::JobCreateRequest,
         analyzer_name_for_log: &str,
         observable_for_log: &str,
+        max_retries: usize,
     ) -> Result<cortex_client::models::JobReportResponse, Box<dyn std::error::Error>> {
         use cortex_client::apis::job_api;
         use std::time::Duration;
@@ -154,7 +155,6 @@ mod common {
                         "Attempting to fetch report with retries"
                     );
 
-                    let max_retries = 5;
                     let retry_delay = Duration::from_secs(5);
 
                     for attempt in 1..=max_retries {
@@ -298,6 +298,8 @@ struct AnalyzeIpParams {
         description = "Optional: The name of the AbuseIPDB analyzer instance in Cortex. Defaults to 'AbuseIPDB_1_0'."
     )]
     analyzer_name: Option<String>,
+    #[schemars(description = "Optional: Maximum number of retries to wait for the analyzer job to complete. Defaults to 5.")]
+    max_retries: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -314,6 +316,8 @@ struct AnalyzeWithAbuseFinderParams {
         description = "Optional: The name of the AbuseFinder analyzer instance in Cortex. Defaults to 'AbuseFinder_3_0'."
     )]
     analyzer_name: Option<String>,
+    #[schemars(description = "Optional: Maximum number of retries to wait for the analyzer job to complete. Defaults to 5.")]
+    max_retries: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -324,6 +328,8 @@ struct ScanUrlWithVirusTotalParams {
         description = "Optional: The name of the VirusTotal_Scan analyzer instance in Cortex. Defaults to 'VirusTotal_Scan_3_1'."
     )]
     analyzer_name: Option<String>,
+    #[schemars(description = "Optional: Maximum number of retries to wait for the analyzer job to complete. Defaults to 5.")]
+    max_retries: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -334,6 +340,8 @@ struct AnalyzeUrlWithUrlscanIoParams {
         description = "Optional: The name of the Urlscan_io_Scan analyzer instance in Cortex. Defaults to 'Urlscan_io_Scan_0_1_0'."
     )]
     analyzer_name: Option<String>,
+    #[schemars(description = "Optional: Maximum number of retries to wait for the analyzer job to complete. Defaults to 5.")]
+    max_retries: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -414,12 +422,14 @@ impl CortexToolsServer {
             attributes: None,
         };
 
+        let max_retries = params.max_retries.unwrap_or(5);
         match common::run_job_and_wait_for_report(
             &self.cortex_config,
             &analyzer_worker_id,
             job_create_request,
             &analyzer_name_to_run,
             &ip_to_analyze,
+            max_retries,
         )
         .await
         {
@@ -531,12 +541,14 @@ impl CortexToolsServer {
             attributes: None,
         };
 
+        let max_retries = params.max_retries.unwrap_or(5);
         match common::run_job_and_wait_for_report(
             &self.cortex_config,
             &analyzer_worker_id,
             job_create_request,
             &analyzer_name_to_run,
             &format!("{} ({})", data_to_analyze, data_type),
+            max_retries,
         )
         .await
         {
@@ -634,12 +646,14 @@ impl CortexToolsServer {
             attributes: None,
         };
 
+        let max_retries = params.max_retries.unwrap_or(5);
         match common::run_job_and_wait_for_report(
             &self.cortex_config,
             &analyzer_worker_id,
             job_create_request,
             &analyzer_name_to_run,
             &url_to_scan,
+            max_retries,
         )
         .await
         {
@@ -736,12 +750,14 @@ impl CortexToolsServer {
             attributes: None,
         };
 
+        let max_retries = params.max_retries.unwrap_or(5);
         match common::run_job_and_wait_for_report(
             &self.cortex_config,
             &analyzer_worker_id,
             job_create_request,
             &analyzer_name_to_run,
             &url_to_analyze,
+            max_retries,
         )
         .await
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ struct ScanUrlWithVirusTotalParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-struct ScanUrlWithUrlscanIoParams {
+struct AnalyzeUrlWithUrlscanIoParams {
     #[schemars(description = "The URL to scan.")]
     url: String,
     #[schemars(


### PR DESCRIPTION
Hi, 

this PR adds support for:

1) [URLScan.io analyzer (popular free analyzer in Cortex)](https://thehive-project.github.io/Cortex-Analyzers/analyzers/Urlscan.io/)

2) `max_retries` MCP tool parameter that is configurable per run and can be passed as tool parameter (optional parameter with default 5, but some analyzers take longer time to finish, so this requires adjusting)


Documentation (README) has also been updated to reflect changes.

I tested it locally and everything works as expected, but would like to apologize in advance if code is not perfect in some places (mostly vibe coded as I'm not proficient in Rust).