### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The recommended way to install the MCP Server for Cortex is to download a pre-co
 Alternatively, you can build the server from source (see the [Building](#building) section below).
 
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gbrigandi-mcp-server-cortex).
+
 ## Configuration
 
 The server is configured using the following environment variables:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/gbrigandi-mcp-server-cortex).